### PR TITLE
Python 3 compatibility fixes + CLAUDE.md

### DIFF
--- a/PartTrace/testparticle.py
+++ b/PartTrace/testparticle.py
@@ -102,9 +102,9 @@ class TPRun:
         # checks the time interval is well defined
         #----------------------------------------------------------------------
         if t0 < self.tstart or t0 > self.tend:
-            print 'time (%5.3f) should be between tstart(%5.3f)\
-                   and tend(%5.3f) (both included)' \
-                   % (t0 ,self.tstart,self.tend)
+            print('time (%5.3f) should be between tstart(%5.3f)'
+                  ' and tend(%5.3f) (both included)'
+                  % (t0, self.tstart, self.tend))
 
             return None
         #----------------------------------------------------------------------
@@ -273,15 +273,15 @@ class TPRun:
         # the following function will move all the particles
         # for all time steps
         if self._is3D:
-            print 'calling _moveall3D'
+            print('calling _moveall3D')
             self._moveall3D()
-            print 'calling _pfields3D'
+            print('calling _pfields3D')
             self._pfields3D()
 
         else:
-            print 'calling _moveall'
+            print('calling _moveall')
             self._moveall()
-            print 'calling _pfields'
+            print('calling _pfields')
             self._pfields()
 
     #==========================================================
@@ -386,7 +386,7 @@ class TPRun:
         yc = self._CR['yy'][0] - .5*self._dy
         zc = self._CR['zz'][0] - .5*self._dz
         
-        print 'Going in!'
+        print('Going in!')
         func(self.r,
              self.v,
              self._E,
@@ -616,7 +616,7 @@ class TPRun:
         Creation : 2013-05-01 11:21:19.671182
 
         """
-        print 'Loading particles in a spatially uniform random distribution...'
+        print('Loading particles in a spatially uniform random distribution...')
 
         self._r0  = np.zeros((3, self._npart))
 
@@ -663,7 +663,7 @@ class TPRun:
         Creation : 2013-05-01 11:21:19.671182
 
         """
-        print 'Loading particles in a spatially uniform random distribution...'
+        print('Loading particles in a spatially uniform random distribution...')
 
         self._r0  = np.zeros((3, self._npart))
 
@@ -715,7 +715,7 @@ class TPRun:
         Creation : 2013-05-01 11:21:19.671182
 
         """
-        print 'Loading particles in a spatially uniform random distribution...'
+        print('Loading particles in a spatially uniform random distribution...')
 
         self._r0  = np.zeros((3, self._npart))
 
@@ -769,7 +769,7 @@ class TPRun:
         Creation : 2013-05-01 11:21:19.671182
 
         """
-        print 'Loading particles in a spatially gaussian random distribution...'
+        print('Loading particles in a spatially gaussian random distribution...')
 
         self._r0  = np.zeros((3, self._npart))
 

--- a/py3d/__init__.py
+++ b/py3d/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import sys
 
 from .movie import Movie

--- a/py3d/dump.py
+++ b/py3d/dump.py
@@ -379,7 +379,7 @@ class Dump(object):
         num_parts = self._pop_int(F)
         self._pop_int(F)
 
-        n_bufs = int(np.floor(1.*num_parts/self.bufsize))
+        n_bufs = int(np.floor(num_parts/self.bufsize))
         num_parts_last_buf = num_parts - self.bufsize*n_bufs
 
         if num_parts_last_buf > 0:
@@ -407,7 +407,7 @@ class Dump(object):
         num_parts = self._pop_int(F)
         self._pop_int(F)
 
-        n_bufs = int(np.floor(1.*num_parts/self.bufsize))
+        n_bufs = int(np.floor(num_parts/self.bufsize))
         num_parts_last_buf = num_parts - self.bufsize*n_bufs
 
         if num_parts_last_buf > 0:

--- a/py3d/sub.py
+++ b/py3d/sub.py
@@ -1,6 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
-from scipy.io.idl import readsav 
+from scipy.io import readsav
 from matplotlib.colors import LinearSegmentedColormap
 from matplotlib.ticker import AutoMinorLocator
 from mpl_toolkits.axes_grid1 import make_axes_locatable
@@ -1086,7 +1086,7 @@ def calc_pdf(ar, pdf_min=None, pdf_max=None, weight=100, inc=0, ax=0):
     
     # Find the total length of data set
     # Also this used to use the operator module, but I didn't like that
-    arsize = reduce(lambda x,y: x*y, np.shape(ar),1)
+    arsize = np.prod(np.shape(ar))
 
     # Find the RMS value of data set and normalize to it.
     rmsval = np.sqrt(np.mean(ar**2))

--- a/py3d/vdist.py
+++ b/py3d/vdist.py
@@ -14,7 +14,7 @@ import struct
 import glob
 import pdb
 import warnings
-from scipy.io.idl import readsav
+from scipy.io import readsav
 from scipy.ndimage import gaussian_filter
 
 class VDist(object):


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` — comprehensive codebase documentation for AI assistants and new contributors (repo structure, core classes, utility functions, conventions, HPC context, known gotchas)
- Phase 1 Python 3 compatibility fixes across 5 files (16 lines changed, no logic changes)

## Python 3 Changes

| File | Change |
|------|--------|
| `py3d/__init__.py` | Removed dead `from __future__ import absolute_import` |
| `py3d/sub.py` | `scipy.io.idl` → `scipy.io` (removed in scipy 1.7); `reduce()` → `np.prod()` |
| `py3d/vdist.py` | `scipy.io.idl` → `scipy.io` |
| `py3d/dump.py` | Removed `1.*x/y` float-coercion idiom (unnecessary in Python 3) |
| `PartTrace/testparticle.py` | 10 Python 2 `print '...'` statements → `print('...')` |

## Test plan

- [ ] Verify `python3 -c "import py3d"` succeeds with dependencies installed
- [ ] Spot-check `PartTrace/testparticle.py` print output is unchanged at runtime

https://claude.ai/code/session_01XcRVA2SLcx5e3nCcBemcw7

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcRVA2SLcx5e3nCcBemcw7)_